### PR TITLE
Creating "How to Use" space on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A Visual Studio Code extension that copies code content to the clipboard to be used as context in artificial intelligence platforms.
 
+## How to use
+
+Once the extension is installed, you can right-click on either a directory or a file and select one of the following options:
+
+- Copy to GPT Chat
+- Copy Directory to GPT Chat
+- Prompt to GPT Chat
+
+The `Prompt to GPT Chat` option provides the initial contextualization text to the prompt, which is highly recommended when opening new chats. 
+The other two options put the code in a organized and comprehensive format for the AI. You can place it immediately after the initial text or use it independently.
+
 ## Features
 
 - Copy the content of a single file or multiple files to the clipboard using a specific format


### PR DESCRIPTION
Oi! Cheguei aqui pelo seu post no [tabNews ](https://www.tabnews.com.br/guilhermelim/lucas-montano-e-o-misterio-do-chatgpt-burrificante-um-estudo-de-caso-inovador) e achei a ideia da extensão fantástica. Acredito que o uso seja bem intuitivo mas demorei pra notar que depois de instalado novas opções estavam aparecendo ao clicar com o botão direito nos arquivos. Acho acabei me acostumando a esperar tudo virar um comando na CLI ou coisa assim kkkk

![image](https://github.com/guilhermelim/copy-to-gpt-chat/assets/71408872/31051ce0-b0ac-4d4a-bd14-d42775d58163)

Pra facilitar a vida de outros devs desatentos sugeri essa pequena parte na documentação do Readme.md, percebi que ele também aparece lá na página da loja do VScode então o user não teria margem pra questionar quais as possíveis maneiras de se usar (por mais que não tenha passado de alguns segundos no meu caso acho que é sempre interessante remover essa etapa de dúvida inicial do caminho).

É minha primeira contribuição num projeto OpenSource também então me desculpe se feri qualquer etiqueta/protocolo entre os Devs aqui no github! E fique a vontade para não fazer nada com o PR também.

Abraços e parabéns pelos excelentes textos lá no tabnews!
<3 